### PR TITLE
GEN07662 update django version 2.1.11 -> 2.2.9

### DIFF
--- a/elasticbeanstalk/nova/requirements.txt
+++ b/elasticbeanstalk/nova/requirements.txt
@@ -1,3 +1,3 @@
-Django==2.1.11
+Django==2.2.9
 djangorestframework==3.9.1
 uWSGI==2.0.17.1


### PR DESCRIPTION
### What is this PR for?
- github 보안이슈 Django 2.1.11 -> 2.2.9


### How should this be tested?
test코드는 없습니다. 
travis가 잘 도는지 확인해주시고, 
코드 실행 후 amazon에서 elasticbeanstalk 가 정상작동하는지 확인해 주세요.